### PR TITLE
[BUG] Fix registration using username

### DIFF
--- a/dilogin/src/main/java/di/dilogin/discord/command/DiscordRegisterBukkitCommand.java
+++ b/dilogin/src/main/java/di/dilogin/discord/command/DiscordRegisterBukkitCommand.java
@@ -48,7 +48,7 @@ public class DiscordRegisterBukkitCommand implements DiscordCommand {
 	 */
 	@Override
 	public void execute(String message, MessageReceivedEvent event) {
-		
+
 		if (!MainController.getDILoginController().isRegisterByDiscordCommandEnabled())
 			return;
 
@@ -133,8 +133,11 @@ public class DiscordRegisterBukkitCommand implements DiscordCommand {
 	 * @return Player if exits and is not registered.
 	 */
 	public Optional<Player> catchRegister(String message, MessageReceivedEvent event) {
-		Optional<Player> player = Optional
-				.ofNullable(BukkitApplication.getPlugin().getServer().getPlayer(registerByCode(message).get()));
+		Optional<String> code = registerByCode(message);
+		Optional<Player> player = Optional.empty();
+		if(code.isPresent()){
+		    player = Optional.ofNullable(BukkitApplication.getPlugin().getServer().getPlayer(code.get()));
+		}
 
 		if (!player.isPresent())
 			player = registerByUserName(message, event);
@@ -165,7 +168,7 @@ public class DiscordRegisterBukkitCommand implements DiscordCommand {
 	public Optional<Player> registerByUserName(String message, MessageReceivedEvent event) {
 
 		Optional<Player> playerOpt = Optional
-				.ofNullable(BukkitApplication.getPlugin().getServer().getPlayer("message"));
+				.ofNullable(BukkitApplication.getPlugin().getServer().getPlayer(message));
 
 		if (!playerOpt.isPresent())
 			return Optional.empty();


### PR DESCRIPTION
There is an error when trying to register with username.

Case: 
 as a user i wrote message in discord: **+register LordAlword**

Expected:
 user registered in discord server with name LordAlword

Actual:
 exception throwed with "code not found"
 

Also plugin trying to register user with nickname "message" not parameter **message** value


There is a fix.

Good plugin though! 
Thank you very much! Appreciate your work, glad to help a little.